### PR TITLE
Add name support for assessments

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -13,15 +13,14 @@ const recommendationRoutes = require('./routes/recommendationRoutes');
 const userRoutes = require('./routes/userRoutes');
 
 // Import database connection (comment jika belum ada)
-// const connectDB = require('./db/connection');
+const connectDB = require('./db/connection');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
-// Connect to database (optional for now - comment jika error)
+// Connect to database
 try {
-  // connectDB();
-  console.log('⚠️  Database connection disabled for now');
+  connectDB();
 } catch (error) {
   console.log('⚠️  Database connection error:', error.message);
 }

--- a/backend/db/init-mongo.js
+++ b/backend/db/init-mongo.js
@@ -10,6 +10,7 @@ db.createCollection('recommendations');
 
 // Create indexes for better performance
 db.assessments.createIndex({ "userId": 1 });
+db.assessments.createIndex({ "name": 1 });
 db.assessments.createIndex({ "createdAt": -1 });
 db.users.createIndex({ "email": 1 }, { unique: true });
 db.recommendations.createIndex({ "assessmentId": 1 });

--- a/backend/models/assessmentModel.js
+++ b/backend/models/assessmentModel.js
@@ -142,6 +142,10 @@ const assessmentSchema = new mongoose.Schema({
     required: true,
     index: true
   },
+  name: {
+    type: String,
+    required: true
+  },
   personalData: {
     type: personalDataSchema,
     required: true
@@ -184,6 +188,7 @@ const assessmentSchema = new mongoose.Schema({
 
 // Indexes for better query performance
 assessmentSchema.index({ userId: 1, createdAt: -1 });
+assessmentSchema.index({ name: 1 });
 assessmentSchema.index({ 'personalData.weight': 1 });
 assessmentSchema.index({ 'personalData.height': 1 });
 assessmentSchema.index({ goal: 1 });

--- a/frontend/src/components/AssessmentForm.jsx
+++ b/frontend/src/components/AssessmentForm.jsx
@@ -10,6 +10,7 @@ const AssessmentForm = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   
   const [formData, setFormData] = useState({
+    name: '',
     age: '',
     weight: '',
     height: '',
@@ -51,7 +52,7 @@ const AssessmentForm = () => {
   const validateCurrentStep = () => {
     switch (currentStep) {
       case 1:
-        return formData.age && formData.weight && formData.height;
+        return formData.name && formData.age && formData.weight && formData.height;
       case 2:
         return formData.goal;
       case 3:
@@ -98,6 +99,7 @@ const AssessmentForm = () => {
     
     try {
       const assessmentData = {
+        name: formData.name,
         age: parseInt(formData.age),
         weight: parseFloat(formData.weight),
         height: parseFloat(formData.height),
@@ -145,6 +147,19 @@ const AssessmentForm = () => {
             </div>
             
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Name
+                </label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => handleInputChange('name', e.target.value)}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="e.g., John Doe"
+                />
+              </div>
+
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Age (years)
@@ -302,7 +317,11 @@ const AssessmentForm = () => {
             </div>
             
             <div className="bg-gray-50 rounded-xl p-6 space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div className="text-center">
+                  <p className="text-sm text-gray-600">Name</p>
+                  <p className="text-lg font-semibold">{formData.name}</p>
+                </div>
                 <div className="text-center">
                   <p className="text-sm text-gray-600">Age</p>
                   <p className="text-lg font-semibold">{formData.age} years</p>


### PR DESCRIPTION
## Summary
- store user's name in assessments schema
- save assessments to MongoDB using controller and enable DB connection
- allow lookups by user ID or name
- create index for name in init script
- extend frontend form with name field and include it on submit

## Testing
- `npm test` *(fails: jest not found)*
- `npm start` in backend *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6856975b1d10832887c28811c66a60d3