### PR TITLE
Add example env files and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
+Setelah mengekstrak projek, salin file contoh environment:
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+
 ### 2. Jalankan dengan Docker
 ```bash
 # Start semua services
@@ -338,8 +344,13 @@ docker-compose up --build -d
 Aplikasi siap di-deploy dengan Docker Compose:
 
 1. Clone repository
-2. Jalankan `docker-compose up --build -d`
-3. Akses aplikasi di port yang dikonfigurasi
+2. Salin file `.env.example` ke `.env` untuk backend dan frontend
+   ```bash
+   cp backend/.env.example backend/.env
+   cp frontend/.env.example frontend/.env
+   ```
+3. Jalankan `docker-compose up --build -d`
+4. Akses aplikasi di port yang dikonfigurasi
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+# Backend environment configuration
+PORT=5000
+MONGODB_URI=mongodb://localhost:27017/dietapp
+# Allowed origin for CORS (optional)
+CORS_ORIGIN=http://localhost:3000
+# Node environment
+NODE_ENV=development

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Frontend environment configuration
+VITE_API_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- provide `.env.example` for backend and frontend
- document copying example env files before running Docker Compose

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68569d2cea388328aedd2f746ed6798f