### PR TITLE
Fix frontend history API and add user id

### DIFF
--- a/frontend/src/components/AssessmentForm.jsx
+++ b/frontend/src/components/AssessmentForm.jsx
@@ -99,6 +99,7 @@ const AssessmentForm = () => {
     
     try {
       const assessmentData = {
+        userId: apiUtils.getUserId(),
         name: formData.name,
         age: parseInt(formData.age),
         weight: parseFloat(formData.weight),

--- a/frontend/src/pages/HistoryPage.jsx
+++ b/frontend/src/pages/HistoryPage.jsx
@@ -36,7 +36,7 @@ const HistoryPage = () => {
     try {
       setLoading(true);
       const userId = apiUtils.getUserId();
-      const response = await assessmentAPI.getHistory(userId, currentPage, itemsPerPage);
+    const response = await assessmentAPI.getAssessmentHistory(userId, currentPage, itemsPerPage);
       
       if (response.success) {
         setHistoryData(response.data);

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -36,7 +36,7 @@ const HistoryPage = () => {
     try {
       setLoading(true);
       const userId = apiUtils.getUserId();
-      const response = await assessmentAPI.getHistory(userId, currentPage, itemsPerPage);
+    const response = await assessmentAPI.getAssessmentHistory(userId, currentPage, itemsPerPage);
       
       if (response.success) {
         setHistoryData(response.data);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,6 +4,14 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://backend:5000';
 // API utility functions
 export const apiUtils = {
   formatResponse: (data) => data,
+  getUserId: () => {
+    let userId = localStorage.getItem('dietapp_user_id');
+    if (!userId) {
+      userId = `user_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      localStorage.setItem('dietapp_user_id', userId);
+    }
+    return userId;
+  },
   handleError: (error) => {
     console.error('API Error:', error);
     if (error.response) {


### PR DESCRIPTION
## Summary
- add `getUserId` helper in api service
- send userId in `AssessmentForm` POST payload
- call `getAssessmentHistory` API in history pages

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run lint` in backend *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68569d2bc29c8328b47b1146e6b1c6fd