### PR TITLE
Fix result history import in ResultDisplay

### DIFF
--- a/frontend/src/components/ResultDisplay.jsx
+++ b/frontend/src/components/ResultDisplay.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getAssessmentHistory, formatUserId } from '../services/api';
+import { assessmentAPI } from '../services/api';
 
 const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
   const [history, setHistory] = useState([]);
@@ -13,12 +13,9 @@ const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
   }, [result]);
 
   const loadAssessmentHistory = async () => {
-    if (!result?.name) return;
-    
     setLoadingHistory(true);
     try {
-      const userId = formatUserId(result.name);
-      const response = await getAssessmentHistory(userId);
+      const response = await assessmentAPI.getAssessmentHistory();
       if (response.success) {
         setHistory(response.data.assessments || []);
       }


### PR DESCRIPTION
## Summary
- fix incorrect import usage in `ResultDisplay.jsx`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d07df7808328b6bc5c72255560b2