### PR TITLE
Remove bufferMaxEntries option

### DIFF
--- a/backend/db/connection.js
+++ b/backend/db/connection.js
@@ -10,8 +10,7 @@ const connectDB = async () => {
       maxPoolSize: 10,
       serverSelectionTimeoutMS: 5000,
       socketTimeoutMS: 45000,
-      bufferCommands: false,
-      bufferMaxEntries: 0
+      bufferCommands: false
     };
 
     const conn = await mongoose.connect(mongoURI, options);


### PR DESCRIPTION
## Summary
- clean up MongoDB connection options by removing deprecated `bufferMaxEntries`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e40a46688328ab03129b2c22420c