### PR TITLE
Update goal option values

### DIFF
--- a/frontend/src/components/AssessmentForm.jsx
+++ b/frontend/src/components/AssessmentForm.jsx
@@ -416,9 +416,9 @@ const AssessmentForm = ({ onSubmit, onResult }) => {
           }}
         >
           <option value="">Pilih tujuan Anda</option>
-          <option value="Hidup Sehat">🌱 Hidup Lebih Sehat</option>
-          <option value="Diet">⚡ Menurunkan Berat Badan</option>
-          <option value="Massa Otot">💪 Menambah Massa Otot</option>
+          <option value="hidup_sehat">🌱 Hidup Lebih Sehat</option>
+          <option value="diet">⚡ Menurunkan Berat Badan</option>
+          <option value="massa_otot">💪 Menambah Massa Otot</option>
         </select>
         {errors.goal && <span style={styles.errorMessage}>{errors.goal}</span>}
       </div>

--- a/frontend/src/pages/HistoryPage.jsx
+++ b/frontend/src/pages/HistoryPage.jsx
@@ -266,9 +266,9 @@ const HistoryPage = () => {
                 className="filter-select"
               >
                 <option value="all">Semua Tujuan</option>
-                <option value="Hidup Sehat">Hidup Sehat</option>
-                <option value="Diet">Diet</option>
-                <option value="Massa Otot">Massa Otot</option>
+                <option value="hidup_sehat">Hidup Sehat</option>
+                <option value="diet">Diet</option>
+                <option value="massa_otot">Massa Otot</option>
               </select>
               
               <select

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -266,9 +266,9 @@ const HistoryPage = () => {
                 className="filter-select"
               >
                 <option value="all">Semua Tujuan</option>
-                <option value="Hidup Sehat">Hidup Sehat</option>
-                <option value="Diet">Diet</option>
-                <option value="Massa Otot">Massa Otot</option>
+                <option value="hidup_sehat">Hidup Sehat</option>
+                <option value="diet">Diet</option>
+                <option value="massa_otot">Massa Otot</option>
               </select>
               
               <select


### PR DESCRIPTION
## Summary
- update option values in AssessmentForm to send slugged `goal` strings
- update filters in HistoryPage and NotFoundPage to use new slug values

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6856fb361ccc83288a9e54ac857e1b95