### PR TITLE
Fix goal validation message and add tests

### DIFF
--- a/backend/__tests__/validationMiddleware.test.js
+++ b/backend/__tests__/validationMiddleware.test.js
@@ -1,0 +1,36 @@
+const { validateAssessment } = require('../middleware/validation');
+
+describe('validateAssessment middleware - goal field', () => {
+  const baseBody = { age: 30, weight: 70, height: 170 };
+
+  const create = (bodyOverrides = {}) => {
+    const req = { body: { ...baseBody, ...bodyOverrides } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = jest.fn();
+    return { req, res, next };
+  };
+
+  it('calls next for valid goal values', () => {
+    const { req, res, next } = create({ goal: 'diet' });
+    validateAssessment(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid goal values', () => {
+    const { req, res, next } = create({ goal: 'invalid' });
+    validateAssessment(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: 'Validation failed',
+        errors: ['Goal must be one of: hidup_sehat, diet, massa_otot']
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -32,7 +32,7 @@ const validateAssessment = (req, res, next) => {
   if (!goal) {
     errors.push('Goal is required');
   } else if (!validGoals.includes(goal)) {
-    errors.push('Goal must be one of: hidup_sehat, diet, massa_otot');
+    errors.push(`Goal must be one of: ${validGoals.join(', ')}`);
   }
 
   // Validate diseases (optional)


### PR DESCRIPTION
## Summary
- show enum options dynamically in validation middleware
- add unit tests covering goal validation

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fc7e09b48328940c2c314402de8d