### PR TITLE
Add assessment retrieval API and test

### DIFF
--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -1,0 +1,15 @@
+import { assessmentAPI } from '../services/api.js';
+
+global.fetch = jest.fn(() => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve({ success: true })
+}));
+
+test('getAssessmentById calls correct endpoint', async () => {
+  const id = '123';
+  await assessmentAPI.getAssessmentById(id);
+  expect(global.fetch).toHaveBeenCalledWith(
+    `http://217.15.160.69:5000/api/v1/assessment/${id}`,
+    expect.objectContaining({ method: 'GET' })
+  );
+});

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -114,6 +114,26 @@ export const assessmentAPI = {
     }
   },
 
+  // Get assessment by ID
+  getAssessmentById: async (id) => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/assessment/${id}`, {
+        method: 'GET',
+        headers: apiUtils.createHeaders()
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Failed to get assessment');
+      }
+
+      return data;
+    } catch (error) {
+      return apiUtils.handleError(error);
+    }
+  },
+
   // Update user preferences
   updateUserPreferences: async (userId, preferences) => {
     try {


### PR DESCRIPTION
## Summary
- implement `getAssessmentById` in the frontend API service
- export via `assessmentAPI`
- add unit test for URL construction

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest ../frontend/src/__tests__/api.test.js` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68572d90feb48328902e9e7cf0cf2227