### PR TITLE
Fix getAssessmentById lookup

### DIFF
--- a/backend/__tests__/assessmentController.test.js
+++ b/backend/__tests__/assessmentController.test.js
@@ -1,0 +1,25 @@
+const Assessment = require('../models/assessmentModel');
+const { getAssessmentById } = require('../controllers/assessmentController');
+
+jest.mock('../models/assessmentModel');
+
+describe('getAssessmentById controller', () => {
+  it('retrieves an existing assessment', async () => {
+    const mockAssessment = { _id: '123', name: 'Test User' };
+    Assessment.findById.mockResolvedValue(mockAssessment);
+
+    const req = { params: { assessmentId: '123' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await getAssessmentById(req, res);
+
+    expect(Assessment.findById).toHaveBeenCalledWith('123');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: mockAssessment
+      })
+    );
+  });
+});

--- a/backend/controllers/assessmentController.js
+++ b/backend/controllers/assessmentController.js
@@ -165,14 +165,19 @@ const validateAssessmentData = async (req, res) => {
 const getAssessmentById = async (req, res) => {
   try {
     const { assessmentId } = req.params;
-    
+    const assessment = await Assessment.findById(assessmentId);
+
+    if (!assessment) {
+      return res.status(404).json({
+        success: false,
+        message: 'Assessment not found'
+      });
+    }
+
     res.status(200).json({
       success: true,
       message: 'Assessment retrieved',
-      data: {
-        id: assessmentId,
-        message: 'Assessment data would be here'
-      }
+      data: assessment
     });
 
   } catch (error) {


### PR DESCRIPTION
## Summary
- lookup assessments by `_id` in controller and return 404 when missing
- test controller retrieving an existing assessment document

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572d92e25883289b190fa926f0ef02