### PR TITLE
Fix assessment form payload types

### DIFF
--- a/frontend/src/components/AssessmentForm.jsx
+++ b/frontend/src/components/AssessmentForm.jsx
@@ -18,7 +18,19 @@ const AssessmentForm = ({ onSubmit }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (onSubmit) {
-      onSubmit(formData);
+      const processedData = {
+        ...formData,
+        age: Number(formData.age),
+        weight: Number(formData.weight),
+        height: Number(formData.height),
+        diseases: formData.diseases
+          ? formData.diseases
+              .split(',')
+              .map((v) => v.trim().toLowerCase())
+              .filter(Boolean)
+          : [],
+      };
+      onSubmit(processedData);
     }
   };
 
@@ -66,13 +78,17 @@ const AssessmentForm = ({ onSubmit }) => {
       </div>
       <div>
         <label htmlFor="goal">Goal</label>
-        <input
+        <select
           id="goal"
           name="goal"
-          type="text"
           value={formData.goal}
           onChange={handleChange}
-        />
+        >
+          <option value="">Select Goal</option>
+          <option value="hidup_sehat">Hidup Sehat</option>
+          <option value="diet">Diet</option>
+          <option value="massa_otot">Massa Otot</option>
+        </select>
       </div>
       <div>
         <label htmlFor="diseases">Diseases</label>

--- a/frontend/src/pages/AssessmentPage.jsx
+++ b/frontend/src/pages/AssessmentPage.jsx
@@ -11,7 +11,8 @@ const AssessmentPage = () => {
   const handleSubmit = async (formData) => {
     setIsSubmitting(true);
     try {
-      const result = await assessmentAPI.submitAssessment(formData);
+      const payload = { ...formData };
+      const result = await assessmentAPI.submitAssessment(payload);
       if (result.error) {
         throw new Error(result.message);
       }


### PR DESCRIPTION
## Summary
- convert number fields in `AssessmentForm` before calling `onSubmit`
- make `goal` a `<select>` with preset options
- parse comma separated diseases into an array
- pass processed data in `AssessmentPage`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in backend *(fails: missing eslint config)*
- `npm run lint` in frontend *(fails: missing eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6857355bcc988328a056a83450547e4a