### PR TITLE
Fix result object usage on results page

### DIFF
--- a/frontend/src/pages/ResultsPage.jsx
+++ b/frontend/src/pages/ResultsPage.jsx
@@ -213,6 +213,16 @@ const ResultsPage = () => {
     );
   }
 
+  const result = assessmentData ? {
+    name: assessmentData.name,
+    ...assessmentData.results.analysis,
+    mealPlan: assessmentData.results.mealPlan,
+    recommendations: assessmentData.results.recommendations,
+    summary: assessmentData.results.summary,
+    healthScore: assessmentData.results.healthScore,
+    nextSteps: assessmentData.results.nextSteps,
+  } : null;
+
   // Success state
   return (
     <div className="results-page">
@@ -244,7 +254,7 @@ const ResultsPage = () => {
       {/* Results Content */}
       <div className="results-content">
         {assessmentData ? (
-          <ResultDisplay assessmentData={assessmentData} />
+          <ResultDisplay result={result} />
         ) : (
           <div className="no-data">
             <p>Data asesmen tidak tersedia</p>


### PR DESCRIPTION
## Summary
- construct a `result` object from `assessmentData`
- pass the new object into `ResultDisplay`

## Testing
- `npm test` (fails: jest not found)
- `npm run lint` in frontend (fails: ESLint config missing)


------
https://chatgpt.com/codex/tasks/task_e_685749821dbc8328ae25719ce8ee7f7f