### PR TITLE
Fix recommendations button routing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { Toaster } from 'react-hot-toast';
 import HomePage from '@/pages/HomePage';
 import AssessmentPage from '@/pages/AssessmentPage';
 import ResultsPage from '@/pages/ResultsPage';
+import RecommendationsPage from '@/pages/RecommendationsPage';
 import HistoryPage from '@/pages/HistoryPage';
 import NotFoundPage from '@/pages/NotFoundPage';
 
@@ -33,6 +34,7 @@ function App() {
               {/* Assessment Flow */}
               <Route path="/assessment" element={<AssessmentPage />} />
               <Route path="/results/:assessmentId" element={<ResultsPage />} />
+              <Route path="/recommendations" element={<RecommendationsPage />} />
               
               {/* User History */}
               <Route path="/history" element={<HistoryPage />} />

--- a/frontend/src/pages/RecommendationsPage.jsx
+++ b/frontend/src/pages/RecommendationsPage.jsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { assessmentAPI } from '../services/api';
+import LoadingSpinner, { PageLoader } from '../components/LoadingSpinner';
+import { ArrowLeft } from 'lucide-react';
+
+const RecommendationsPage = () => {
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await assessmentAPI.getRecommendations();
+        if (response.success) {
+          setData(response.data);
+        } else {
+          console.error('Failed to load recommendations');
+        }
+      } catch (error) {
+        console.error('Error fetching recommendations:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return <PageLoader message="Memuat menu makanan..." />;
+  }
+
+  if (!data?.meals?.length) {
+    return (
+      <div className="container" style={{ padding: '60px 0' }}>
+        <h1>Tidak ada rekomendasi tersedia</h1>
+        <button onClick={() => navigate(-1)} className="btn btn-primary" style={{ marginTop: '16px' }}>
+          Kembali
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="recommendations-page" style={{ padding: '40px 0' }}>
+      <div className="container">
+        <div className="page-header" style={{ marginBottom: '24px', display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <button onClick={() => navigate(-1)} className="btn btn-secondary btn-small">
+            <ArrowLeft size={18} />
+            Kembali
+          </button>
+          <h1 style={{ margin: 0 }}>Menu Makanan Sehat</h1>
+        </div>
+        <div className="meal-grid" style={{ display: 'grid', gap: '24px', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))' }}>
+          {data.meals.map((meal) => (
+            <div key={meal.id} className="meal-card" style={{ border: '1px solid #e5e7eb', borderRadius: '12px', padding: '16px', background: 'white' }}>
+              {meal.image && (
+                <img src={meal.image} alt={meal.name} style={{ width: '100%', borderRadius: '8px', marginBottom: '12px' }} />
+              )}
+              <h3 style={{ marginTop: 0 }}>{meal.name}</h3>
+              <p>{meal.description}</p>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '12px', fontWeight: 'bold' }}>
+                <span>{meal.calories} kkal</span>
+                <span>Rp{meal.price}</span>
+              </div>
+              <button className="btn btn-primary btn-small" style={{ marginTop: '16px', width: '100%' }}>
+                Order
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RecommendationsPage;

--- a/frontend/src/pages/ResultsPage.jsx
+++ b/frontend/src/pages/ResultsPage.jsx
@@ -73,6 +73,10 @@ const ResultsPage = () => {
     navigate('/assessment');
   };
 
+  const handleGoToMenu = () => {
+    navigate('/recommendations');
+  };
+
   // Loading state
   if (loading) {
     return (
@@ -254,7 +258,11 @@ const ResultsPage = () => {
       {/* Results Content */}
       <div className="results-content">
         {assessmentData ? (
-          <ResultDisplay result={result} />
+          <ResultDisplay
+            result={result}
+            onBackToAssessment={handleNewAssessment}
+            onGoToMenu={handleGoToMenu}
+          />
         ) : (
           <div className="no-data">
             <p>Data asesmen tidak tersedia</p>


### PR DESCRIPTION
## Summary
- implement a simple `RecommendationsPage` that fetches menu data
- add route `/recommendations`
- pass navigation handler so the results page button works

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68575048fb2883288f8c4a9cf77d782a