### PR TITLE
Add diet meal recommendations

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -592,3 +592,24 @@ body {
 .text-success { color: var(--success-color); }
 .text-warning { color: var(--warning-color); }
 .text-error { color: var(--error-color); }
+/* Modal styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 400px;
+  width: 90%;
+}

--- a/frontend/src/components/MealModal.jsx
+++ b/frontend/src/components/MealModal.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const MealModal = ({ meal, onClose }) => {
+  if (!meal) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2>{meal.name}</h2>
+        {meal.image && (
+          <img
+            src={meal.image}
+            alt={meal.name}
+            style={{ width: '100%', borderRadius: '8px', marginBottom: '12px' }}
+          />
+        )}
+        <p>{meal.description}</p>
+        {meal.calories && (
+          <p><strong>Kalori:</strong> {meal.calories} kkal</p>
+        )}
+        <button className="btn btn-secondary" onClick={onClose} style={{ marginTop: '12px' }}>
+          Tutup
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MealModal;

--- a/frontend/src/components/RecommendationList.jsx
+++ b/frontend/src/components/RecommendationList.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const RecommendationList = ({ meals, onSelect }) => (
+  <div className="meal-grid">
+    {meals.map((meal) => (
+      <div
+        key={meal.id}
+        className="meal-card"
+        onClick={() => onSelect && onSelect(meal)}
+        style={{ cursor: 'pointer' }}
+      >
+        {meal.image && (
+          <img
+            src={meal.image}
+            alt={meal.name}
+            style={{ width: '100%', borderRadius: '8px', marginBottom: '12px' }}
+          />
+        )}
+        <h3 style={{ marginTop: 0 }}>{meal.name}</h3>
+        <p>{meal.description}</p>
+        {meal.calories && (
+          <p style={{ fontWeight: 'bold' }}>{meal.calories} kkal</p>
+        )}
+      </div>
+    ))}
+  </div>
+);
+
+export default RecommendationList;

--- a/frontend/src/components/ResultDisplay.jsx
+++ b/frontend/src/components/ResultDisplay.jsx
@@ -1,14 +1,21 @@
 import React, { useState, useEffect } from 'react';
 import { assessmentAPI } from '../services/api';
+import { getMealsForUser } from '../mealRecommendations';
+import RecommendationList from './RecommendationList';
+import MealModal from './MealModal';
 
 const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
   const [history, setHistory] = useState([]);
   const [showHistory, setShowHistory] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
+  const [recommendedMeals, setRecommendedMeals] = useState([]);
+  const [selectedMeal, setSelectedMeal] = useState(null);
 
   useEffect(() => {
     if (result && result.name) {
       loadAssessmentHistory();
+      const meals = getMealsForUser(result.goal, result.diseases || []);
+      setRecommendedMeals(meals);
     }
   }, [result]);
 
@@ -42,12 +49,6 @@ const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
     return '#f44336';
   };
 
-  const sampleFoods = React.useMemo(() => {
-    if (!result?.mealPlan?.meals) return [];
-    const foods = result.mealPlan.meals.flatMap(m => m.suggestions || []);
-    const unique = Array.from(new Set(foods));
-    return unique.slice(0, 4);
-  }, [result]);
 
   const formatDate = (dateString) => {
     const date = new Date(dateString);
@@ -78,14 +79,10 @@ const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
         <p>Halo <strong>{result.name}</strong>, berikut analisis kesehatan Anda</p>
       </div>
 
-      {sampleFoods.length > 0 && (
-        <div style={{ textAlign: 'center', marginBottom: '24px' }}>
-          <h3>Rekomendasi Makanan</h3>
-          <ul style={{ listStyle: 'none', padding: 0 }}>
-            {sampleFoods.map((food, idx) => (
-              <li key={idx}>{food}</li>
-            ))}
-          </ul>
+      {recommendedMeals.length > 0 && (
+        <div style={{ marginBottom: '24px' }}>
+          <h3 style={{ textAlign: 'center', marginBottom: '16px' }}>Rekomendasi Makanan</h3>
+          <RecommendationList meals={recommendedMeals} onSelect={setSelectedMeal} />
         </div>
       )}
 
@@ -273,6 +270,8 @@ const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
       <div className="disclaimer">
         <p>⚠️ <strong>Penting:</strong> Hasil assessment ini bersifat informatif dan tidak menggantikan konsultasi medis profesional. Untuk kondisi kesehatan khusus, disarankan berkonsultasi dengan dokter atau ahli gizi.</p>
       </div>
+
+      <MealModal meal={selectedMeal} onClose={() => setSelectedMeal(null)} />
     </div>
   );
 };

--- a/frontend/src/mealRecommendations.js
+++ b/frontend/src/mealRecommendations.js
@@ -1,0 +1,81 @@
+const mealRecommendations = {
+  "diet:diabetes": [
+    {
+      id: "meal1",
+      name: "Oat & Telur Rebus",
+      description: "Oatmeal tinggi serat dengan telur rebus dan tomat",
+      image: "https://source.unsplash.com/featured/?oatmeal",
+      calories: 300
+    },
+    {
+      id: "meal2",
+      name: "Salad Ayam",
+      description: "Dada ayam panggang dengan sayuran segar",
+      image: "https://source.unsplash.com/featured/?chicken,salad",
+      calories: 350
+    },
+    {
+      id: "meal3",
+      name: "Ikan Bakar",
+      description: "Ikan bakar dengan nasi merah",
+      image: "https://source.unsplash.com/featured/?grilled,fish",
+      calories: 400
+    },
+    {
+      id: "meal4",
+      name: "Smoothie Berry",
+      description: "Smoothie rendah gula dengan buah berry",
+      image: "https://source.unsplash.com/featured/?berry,smoothie",
+      calories: 180
+    }
+  ],
+  "diet:hipertensi": [
+    {
+      id: "meal5",
+      name: "Sayur Bayam",
+      description: "Tumis bayam rendah garam dengan tahu",
+      image: "https://source.unsplash.com/featured/?spinach",
+      calories: 250
+    },
+    {
+      id: "meal6",
+      name: "Grilled Salmon",
+      description: "Salmon panggang dengan brokoli",
+      image: "https://source.unsplash.com/featured/?salmon",
+      calories: 420
+    }
+  ],
+  "diet:none": [
+    {
+      id: "meal7",
+      name: "Ayam Panggang",
+      description: "Ayam panggang dengan salad",
+      image: "https://source.unsplash.com/featured/?grilled,chicken",
+      calories: 400
+    },
+    {
+      id: "meal8",
+      name: "Nasi Merah dan Tempe",
+      description: "Paket lengkap nasi merah dengan tempe",
+      image: "https://source.unsplash.com/featured/?tempeh",
+      calories: 450
+    }
+  ]
+};
+
+export function getMealsForUser(goal, diseases = []) {
+  const allMeals = [];
+  diseases.forEach(disease => {
+    const key = `${goal}:${disease}`;
+    if (mealRecommendations[key]) {
+      allMeals.push(...mealRecommendations[key]);
+    }
+  });
+  if (allMeals.length === 0 && mealRecommendations[`${goal}:none`]) {
+    allMeals.push(...mealRecommendations[`${goal}:none`]);
+  }
+  const uniqueMeals = [...new Map(allMeals.map(m => [m.id, m])).values()];
+  return uniqueMeals.slice(0, 4);
+}
+
+export default mealRecommendations;

--- a/frontend/src/pages/ResultsPage.jsx
+++ b/frontend/src/pages/ResultsPage.jsx
@@ -219,6 +219,8 @@ const ResultsPage = () => {
 
   const result = assessmentData ? {
     name: assessmentData.name,
+    goal: assessmentData.goal,
+    diseases: assessmentData.diseases,
     ...assessmentData.results.analysis,
     mealPlan: assessmentData.results.mealPlan,
     recommendations: assessmentData.results.recommendations,


### PR DESCRIPTION
## Summary
- add static mealRecommendations data and selector function
- show meal recommendation list on Results page
- support modal display for meal details
- include basic modal styles

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685756fe55bc8328a5f17bb8739cc9df