### PR TITLE
Add user recommendation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Aplikasi menggunakan arsitektur **frontend-backend sederhana**:
 - **Database**: MongoDB (opsional)
 - **Endpoints**:
   - `POST /api/v1/assessment` - Submit asesmen
-  - `GET /api/v1/recommendation/:userid` - Get rekomendasi
+  - `GET /api/v1/recommendation/:userid` - Rekomendasi berdasarkan asesmen terakhir
 
 ### Frontend
 - **Framework**: React + Vite
@@ -110,6 +110,7 @@ Backend akan mengubah nilai tersebut menjadi label yang lebih ramah pada respon 
 ```bash
 GET /api/v1/recommendation/:userid
 ```
+Mengembalikan `mealPlan`, `recommendations`, dan `restrictions` dari asesmen terakhir pengguna.
 
 ## 🗂️ Project Structure
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -119,7 +119,8 @@ app.get('/api', (req, res) => {
       recommendation: {
         get: 'GET /api/v1/recommendation',
         getById: 'GET /api/v1/recommendation/:mealId',
-        filter: 'POST /api/v1/recommendation/filter'
+        filter: 'POST /api/v1/recommendation/filter',
+        user: 'GET /api/v1/recommendation/:userId'
       },
       user: {
         profile: 'GET /api/v1/user/profile',

--- a/backend/controllers/recommendationController.js
+++ b/backend/controllers/recommendationController.js
@@ -1,0 +1,30 @@
+const Assessment = require('../models/assessmentModel');
+
+const getUserRecommendations = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const assessment = await Assessment.findOne({ userId }).sort({ createdAt: -1 });
+
+    if (!assessment) {
+      return res.status(404).json({
+        success: false,
+        message: 'Assessment not found for this user'
+      });
+    }
+
+    const { mealPlan, recommendations, restrictions } = assessment.results || {};
+
+    res.status(200).json({
+      success: true,
+      data: { mealPlan, recommendations, restrictions }
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: 'Failed to get user recommendations',
+      error: error.message
+    });
+  }
+};
+
+module.exports = { getUserRecommendations };

--- a/backend/routes/recommendationRoutes.js
+++ b/backend/routes/recommendationRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const recommendationController = require('../controllers/recommendationController');
 
 // GET /api/v1/recommendation - Get food recommendations based on assessment
 router.get('/', async (req, res) => {
@@ -63,6 +64,9 @@ router.get('/', async (req, res) => {
     });
   }
 });
+
+// GET /api/v1/recommendation/:userId - Get recommendations for a user
+router.get('/:userId', recommendationController.getUserRecommendations);
 
 // GET /api/v1/recommendation/:mealId - Get specific meal details
 router.get('/:mealId', async (req, res) => {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -76,7 +76,8 @@ export const assessmentAPI = {
   getRecommendations: async (userId) => {
     try {
       const id = userId || apiUtils.getUserId();
-      const response = await fetch(`${API_BASE_URL}/api/v1/recommendation/${id}`, {
+      const endpoint = `${API_BASE_URL}/api/v1/recommendation/${id}`;
+      const response = await fetch(endpoint, {
         method: 'GET',
         headers: apiUtils.createHeaders()
       });


### PR DESCRIPTION
## Summary
- support fetching user recommendations via latest assessment
- document new endpoint in API docs
- expose route in backend API explorer
- update frontend service call

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6857776167a0832897b66f1e34cb184b