### PR TITLE
Fix routing conflict for recommendation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Aplikasi menggunakan arsitektur **frontend-backend sederhana**:
 - **Database**: MongoDB (opsional)
 - **Endpoints**:
   - `POST /api/v1/assessment` - Submit asesmen
-  - `GET /api/v1/recommendation/:userid` - Rekomendasi berdasarkan asesmen terakhir
+  - `GET /api/v1/recommendation/user/:userid` - Rekomendasi berdasarkan asesmen terakhir
 
 ### Frontend
 - **Framework**: React + Vite
@@ -108,7 +108,7 @@ Backend akan mengubah nilai tersebut menjadi label yang lebih ramah pada respon 
 
 ### Recommendation Endpoint
 ```bash
-GET /api/v1/recommendation/:userid
+GET /api/v1/recommendation/user/:userid
 ```
 Mengembalikan `mealPlan`, `recommendations`, dan `restrictions` dari asesmen terakhir pengguna.
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -118,9 +118,9 @@ app.get('/api', (req, res) => {
       },
       recommendation: {
         get: 'GET /api/v1/recommendation',
-        getById: 'GET /api/v1/recommendation/:mealId',
+        getById: 'GET /api/v1/recommendation/meal/:mealId',
         filter: 'POST /api/v1/recommendation/filter',
-        user: 'GET /api/v1/recommendation/:userId'
+        user: 'GET /api/v1/recommendation/user/:userId'
       },
       user: {
         profile: 'GET /api/v1/user/profile',

--- a/backend/routes/recommendationRoutes.js
+++ b/backend/routes/recommendationRoutes.js
@@ -65,11 +65,8 @@ router.get('/', async (req, res) => {
   }
 });
 
-// GET /api/v1/recommendation/:userId - Get recommendations for a user
-router.get('/:userId', recommendationController.getUserRecommendations);
-
-// GET /api/v1/recommendation/:mealId - Get specific meal details
-router.get('/:mealId', async (req, res) => {
+// GET /api/v1/recommendation/meal/:mealId - Get specific meal details
+router.get('/meal/:mealId', async (req, res) => {
   try {
     const { mealId } = req.params;
     
@@ -115,6 +112,9 @@ router.get('/:mealId', async (req, res) => {
     });
   }
 });
+
+// GET /api/v1/recommendation/user/:userId - Get recommendations for a user
+router.get('/user/:userId', recommendationController.getUserRecommendations);
 
 // POST /api/v1/recommendation/filter - Filter recommendations
 router.post('/filter', async (req, res) => {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -76,7 +76,7 @@ export const assessmentAPI = {
   getRecommendations: async (userId) => {
     try {
       const id = userId || apiUtils.getUserId();
-      const endpoint = `${API_BASE_URL}/api/v1/recommendation/${id}`;
+      const endpoint = `${API_BASE_URL}/api/v1/recommendation/user/${id}`;
       const response = await fetch(endpoint, {
         method: 'GET',
         headers: apiUtils.createHeaders()


### PR DESCRIPTION
## Summary
- avoid path collision in recommendation routes
- update API endpoint documentation
- update frontend API client for new path

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68577b4cca9c8328b6ab6f9fea0407b8