### PR TITLE
Implement generic meal recommendation fetch

### DIFF
--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -5,11 +5,23 @@ global.fetch = jest.fn(() => Promise.resolve({
   json: () => Promise.resolve({ success: true })
 }));
 
+beforeEach(() => {
+  global.fetch.mockClear();
+});
+
 test('getAssessmentById calls correct endpoint', async () => {
   const id = '123';
   await assessmentAPI.getAssessmentById(id);
   expect(global.fetch).toHaveBeenCalledWith(
     `http://217.15.160.69:5000/api/v1/assessment/${id}`,
+    expect.objectContaining({ method: 'GET' })
+  );
+});
+
+test('getMealRecommendations calls generic endpoint', async () => {
+  await assessmentAPI.getMealRecommendations();
+  expect(global.fetch).toHaveBeenCalledWith(
+    'http://217.15.160.69:5000/api/v1/recommendation',
     expect.objectContaining({ method: 'GET' })
   );
 });

--- a/frontend/src/pages/RecommendationsPage.jsx
+++ b/frontend/src/pages/RecommendationsPage.jsx
@@ -12,7 +12,7 @@ const RecommendationsPage = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await assessmentAPI.getRecommendations();
+        const response = await assessmentAPI.getMealRecommendations();
         if (response.success) {
           setData(response.data);
         } else {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -72,7 +72,7 @@ export const assessmentAPI = {
     }
   },
 
-  // Get recommendations
+  // Get recommendations for a specific user
   getRecommendations: async (userId) => {
     try {
       const id = userId || apiUtils.getUserId();
@@ -81,13 +81,35 @@ export const assessmentAPI = {
         method: 'GET',
         headers: apiUtils.createHeaders()
       });
-      
+
       const data = await response.json();
-      
+
       if (!response.ok) {
         throw new Error(data.message || 'Failed to get recommendations');
       }
-      
+
+      return data;
+    } catch (error) {
+      return apiUtils.handleError(error);
+    }
+  },
+
+  // Get generic meal recommendations
+  getMealRecommendations: async (params = {}) => {
+    try {
+      const searchParams = new URLSearchParams(params).toString();
+      const endpoint = `${API_BASE_URL}/api/v1/recommendation${searchParams ? `?${searchParams}` : ''}`;
+      const response = await fetch(endpoint, {
+        method: 'GET',
+        headers: apiUtils.createHeaders()
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Failed to get recommendations');
+      }
+
       return data;
     } catch (error) {
       return apiUtils.handleError(error);


### PR DESCRIPTION
## Summary
- fetch meal recommendations without user id
- call `getMealRecommendations` from RecommendationsPage
- test API utility for meal recommendations

## Testing
- `npm test` in `backend`
- `npx jest frontend/src/__tests__/api.test.js` *(fails: Could not find config file)*

------
https://chatgpt.com/codex/tasks/task_e_68577b4b920083289a57f67aa1cd3454