### PR TITLE
Add mealPlan handling test for recommendations

### DIFF
--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { assessmentAPI } from '../services/api.js';
 
 global.fetch = jest.fn(() => Promise.resolve({
@@ -7,6 +8,10 @@ global.fetch = jest.fn(() => Promise.resolve({
 
 beforeEach(() => {
   global.fetch.mockClear();
+  global.localStorage = {
+    getItem: jest.fn(),
+    setItem: jest.fn()
+  };
 });
 
 test('getAssessmentById calls correct endpoint', async () => {
@@ -24,4 +29,16 @@ test('getMealRecommendations calls generic endpoint', async () => {
     'http://217.15.160.69:5000/api/v1/recommendation',
     expect.objectContaining({ method: 'GET' })
   );
+});
+
+test('getRecommendations returns meals array from mealPlan', async () => {
+  const meals = [{ id: 1 }, { id: 2 }];
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ success: true, data: { mealPlan: { meals } } })
+  });
+
+  const result = await assessmentAPI.getRecommendations();
+
+  expect(result).toEqual(meals);
 });

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,7 @@
 // frontend/src/services/api.js
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://217.15.160.69:5000';
+const API_BASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_URL) ||
+  'http://217.15.160.69:5000';
 
 // API utility functions
 export const apiUtils = {
@@ -86,6 +88,10 @@ export const assessmentAPI = {
 
       if (!response.ok) {
         throw new Error(data.message || 'Failed to get recommendations');
+      }
+
+      if (data?.data?.mealPlan?.meals) {
+        return data.data.mealPlan.meals;
       }
 
       return data;


### PR DESCRIPTION
## Summary
- handle undefined `import.meta.env` in API service
- extract `mealPlan.meals` in `getRecommendations`
- extend API tests to cover mealPlan handling

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest ../frontend/src/__tests__/api.test.js --runInBand --config '{"rootDir":"../frontend"}'`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68578da3932c8328bc5f321649bf0474