### PR TITLE
Fix BMI analysis path in result display

### DIFF
--- a/frontend/src/components/ResultDisplay.jsx
+++ b/frontend/src/components/ResultDisplay.jsx
@@ -106,9 +106,9 @@ const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
           <h3>Indeks Massa Tubuh (BMI)</h3>
           <div className="bmi-display">
             <div className="bmi-value">
-              <span className="bmi-number">{result.results?.bmi?.toFixed(1)}</span>
-              <span className={`bmi-category ${getBMICategoryClass(result.results?.bmiCategory)}`}>
-                {result.results?.bmiCategory}
+              <span className="bmi-number">{result.results?.analysis?.bmi?.toFixed(1)}</span>
+              <span className={`bmi-category ${getBMICategoryClass(result.results?.analysis?.bmiCategory)}`}>
+                {result.results?.analysis?.bmiCategory}
               </span>
             </div>
           </div>
@@ -195,7 +195,7 @@ const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
                         {new Date(assessment.createdAt).toLocaleDateString('id-ID')}
                       </div>
                       <div className="history-details">
-                        <span>BMI: {assessment.results?.bmi?.toFixed(1)} ({assessment.results?.bmiCategory})</span>
+                        <span>BMI: {assessment.results?.analysis?.bmi?.toFixed(1)} ({assessment.results?.analysis?.bmiCategory})</span>
                         <span>Tujuan: {assessment.goal}</span>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- reference analysis fields when showing BMI and BMI category

## Testing
- `npm test` (backend)
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run lint` in frontend *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6857935a30808328a947a812ec1d4e87