### PR TITLE
Fix getRecommendations return type

### DIFF
--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -31,14 +31,15 @@ test('getMealRecommendations calls generic endpoint', async () => {
   );
 });
 
-test('getRecommendations returns meals array from mealPlan', async () => {
+test('getRecommendations returns full JSON response', async () => {
   const meals = [{ id: 1 }, { id: 2 }];
+  const apiResponse = { success: true, data: { mealPlan: { meals } } };
   global.fetch.mockResolvedValueOnce({
     ok: true,
-    json: () => Promise.resolve({ success: true, data: { mealPlan: { meals } } })
+    json: () => Promise.resolve(apiResponse)
   });
 
   const result = await assessmentAPI.getRecommendations();
 
-  expect(result).toEqual(meals);
+  expect(result).toEqual(apiResponse);
 });

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -90,10 +90,6 @@ export const assessmentAPI = {
         throw new Error(data.message || 'Failed to get recommendations');
       }
 
-      if (data?.data?.mealPlan?.meals) {
-        return data.data.mealPlan.meals;
-      }
-
       return data;
     } catch (error) {
       return apiUtils.handleError(error);


### PR DESCRIPTION
## Summary
- simplify `getRecommendations` and always return full JSON
- update unit test for new return type

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68579b9266c08328aeb0c4ae3a51d1e0