### PR TITLE
Update recommendation endpoint to return meals list

### DIFF
--- a/backend/controllers/recommendationController.js
+++ b/backend/controllers/recommendationController.js
@@ -12,11 +12,37 @@ const getUserRecommendations = async (req, res) => {
       });
     }
 
-    const { mealPlan, recommendations, restrictions } = assessment.results || {};
+  const { mealPlan = {}, recommendations, restrictions } = assessment.results || {};
+
+    // Flatten meals array and provide defaults if empty
+    const meals = Array.isArray(mealPlan.meals) ? [...mealPlan.meals] : [];
+
+    if (meals.length === 0) {
+      meals.push(
+        {
+          id: 'default1',
+          name: 'Paket Sehat Harian',
+          description: 'Nasi merah, ayam panggang dan sayur bayam',
+          calories: 450
+        },
+        {
+          id: 'default2',
+          name: 'Salad Quinoa',
+          description: 'Quinoa dengan dada ayam dan sayuran segar',
+          calories: 350
+        },
+        {
+          id: 'default3',
+          name: 'Smoothie Protein',
+          description: 'Smoothie protein dengan buah dan sayur',
+          calories: 300
+        }
+      );
+    }
 
     res.status(200).json({
       success: true,
-      data: { mealPlan, recommendations, restrictions }
+      data: { meals, mealPlan, recommendations, restrictions }
     });
   } catch (error) {
     res.status(500).json({

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -33,7 +33,7 @@ test('getMealRecommendations calls generic endpoint', async () => {
 
 test('getRecommendations returns full JSON response', async () => {
   const meals = [{ id: 1 }, { id: 2 }];
-  const apiResponse = { success: true, data: { mealPlan: { meals } } };
+  const apiResponse = { success: true, data: { meals } };
   global.fetch.mockResolvedValueOnce({
     ok: true,
     json: () => Promise.resolve(apiResponse)

--- a/frontend/src/components/ResultDisplay.jsx
+++ b/frontend/src/components/ResultDisplay.jsx
@@ -27,9 +27,9 @@ const ResultDisplay = ({ result, onBackToAssessment, onGoToMenu }) => {
     try {
       const response = await assessmentAPI.getRecommendations();
       if (response.success) {
-        const { mealPlan } = response.data || {};
-        const meals = mealPlan?.meals || [];
-        setRecommendedMeals(meals);
+        const { meals, mealPlan } = response.data || {};
+        const mealList = meals && meals.length > 0 ? meals : mealPlan?.meals || [];
+        setRecommendedMeals(mealList);
       }
     } catch (error) {
       console.error('Failed to load meal recommendations:', error);


### PR DESCRIPTION
## Summary
- enhance the user recommendation controller to always send a meals array
- show the meals array on the frontend and fall back to the old mealPlan
- adjust related frontend test

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68579c53059c8328b34161e621547371