### PR TITLE
Add disease-specific meals for healthy living

### DIFF
--- a/frontend/src/components/RecommendationList.jsx
+++ b/frontend/src/components/RecommendationList.jsx
@@ -43,6 +43,26 @@ const staticMeals = {
     ]
   },
   hidup_sehat: {
+    diabetes: [
+      'Nasi merah + tumis buncis',
+      'Ayam kukus tanpa kulit',
+      'Smoothie sayur rendah gula'
+    ],
+    hipertensi: [
+      'Sup bening bayam',
+      'Ikan panggang tanpa garam',
+      'Tempe kukus + brokoli'
+    ],
+    kolesterol: [
+      'Tumis tahu + sayur hijau',
+      'Nasi merah + ikan kukus',
+      'Sup labu tanpa santan'
+    ],
+    asam_urat: [
+      'Salad sayur segar',
+      'Ayam rebus + wortel',
+      'Smoothie buah rendah purin'
+    ],
     none: [
       'Nasi merah + tempe goreng kering',
       'Omelet sayur',


### PR DESCRIPTION
## Summary
- extend `staticMeals.hidup_sehat` with lists for diabetes, hipertensi, kolesterol and asam_urat

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run lint` in backend *(fails: ESLint couldn't find configuration)*
- `npm test` in backend *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6857d29331a48328bb1d3c5dae9dcc43